### PR TITLE
supporting puppet-nginx's vhost_cfg_append

### DIFF
--- a/manifests/django.pp
+++ b/manifests/django.pp
@@ -8,7 +8,6 @@ define appdeploy::django (
   $proxy = true,
   $proxy_hosts = [],
   $directory = "/home/$user/$title/src",
-  $websocket = undef,
   $vhost_cfg_append = undef,
 ) {
   include supervisor

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -4,7 +4,6 @@ define appdeploy::proxy (
   $hosts,
   $upstream_ip = '127.0.0.1',
   $upstream_port = 8001,
-  $websocket = undef,
   $vhost_cfg_append = undef,
 ) {
 


### PR DESCRIPTION
Example of usage:

``` ruby
appdeploy::django { 'application':
...
vhost_cfg_append => {
      'error_page 500 502 503 504' => '/static/50x.html',
    },
...
}
```
